### PR TITLE
ステップ9: アプリの日本語部分を共通化しよう

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rails', '~> 5.2.3'
 # require:false > rubocopはターミナルでしか使わないためinstallする必要はない
 gem 'rubocop', require:false
 gem 'rubocop-rails', require:false
+gem 'rails-i18n', '~> 5.1'
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 1.1.4'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.6)
       actionpack (= 5.2.6)
       activesupport (= 5.2.6)
@@ -199,6 +202,7 @@ DEPENDENCIES
   pg (~> 1.1.4)
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-i18n (~> 5.1)
   rubocop
   rubocop-rails
   sass-rails (~> 5.0.7)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,5 @@
 class TasksController < ApplicationController
-  before_action :set_task, only: %i[show edit update]
+  before_action :set_task, only: %i[show edit update destroy]
 
   def index
     @tasks = Task.all
@@ -34,6 +34,12 @@ class TasksController < ApplicationController
       render :edit
       flash[:error] = "An unexpected error has occurred."
     end
+  end
+
+  def destroy
+    @task.destroy
+    redirect_to tasks_url
+    flash[:success] = "Task was successfully destroyed!"
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,9 +1,48 @@
 class TasksController < ApplicationController
+  before_action :set_task, only: %i[show edit update]
+  
   def index
     @tasks = Task.all
   end
 
   def show
     @task = Task.find(params[:id])
+  end
+
+  def new
+    @task = Task.new
+  end
+
+  def edit
+  end
+
+  def create
+    @task = Task.new(task_params)
+    if @task.save
+      redirect_to tasks_url
+      flash[:success] = "Task was successfully created!"
+    else
+      render :new
+      flash[:error] = "An unexpected error has occurred."
+    end
+  end
+
+  def update
+    if @task.update(task_params)
+      redirect_to @task
+      flash[:success] = "Task was successfully updated!"
+    else 
+      render :edit
+      flash[:error] = "An unexpected error has occurred."
+    end
+  end
+
+  private
+  def set_task
+    @task = Task.find(params[:id])
+  end
+
+  def task_params
+    params.require(:task).permit(:title, :description)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,12 +1,11 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %i[show edit update]
-  
+
   def index
     @tasks = Task.all
   end
 
   def show
-    @task = Task.find(params[:id])
   end
 
   def new

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,3 @@
 class Task < ApplicationRecord
+  validates :title, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,9 @@
   </head>
 
   <body>
+    <% flash.each do |message_type, message| %>
+      <div class="alert-<%= message_type %>"><%= message %></div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,6 +1,18 @@
 <style>
-  form div { margin-bottom: 30px }
+  form div { margin-bottom: 30px; display: flex}
+  .alert-error { color: red }
 </style>
+
+<% if @task.errors.any? %>
+<div class="alert alert-error">
+  <h3>err</h3>
+  <ul>
+    <% @task.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end -%>
+  </ul>
+</div>
+<% end -%>
 
 <%= form_with(model: task, local: true) do |f| %>
   <div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,0 +1,17 @@
+<style>
+  form div { margin-bottom: 30px }
+</style>
+
+<%= form_with(model: task, local: true) do |f| %>
+  <div>
+    <%= f.label :title %>
+    <%= f.text_field :title %>
+  </div>
+  <div>
+    <%= f.label :description %>
+    <%= f.text_area :description %>
+  </div>
+  <div>
+    <%= f.submit "送信" %>
+  </div>
+<% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>タスク編集</h1>
+
+<%= render 'form', task: @task %>
+
+<%= link_to '戻る', tasks_path %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -17,6 +17,7 @@
         <td><%= task.title %></td>
         <td><%= link_to '詳細', task %></td>
         <td><%= link_to '編集', edit_task_path(task) %></td>
+        <td><%= link_to '削除', task, method: :delete, date: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -17,7 +17,7 @@
         <td><%= task.title %></td>
         <td><%= link_to '詳細', task %></td>
         <td><%= link_to '編集', edit_task_path(task) %></td>
-        <td><%= link_to '削除', task, method: :delete, date: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to '削除', task, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,6 +3,8 @@
 </style>
 
 <h1>タスク一覧</h1>
+<p><%= link_to '新規作成', new_task_path %></p>
+
 <table>
   <thead>
     <tr>
@@ -14,6 +16,7 @@
       <tr>
         <td><%= task.title %></td>
         <td><%= link_to '詳細', task %></td>
+        <td><%= link_to '編集', edit_task_path(task) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,0 +1,5 @@
+<h1>タスク作成</h1>
+
+<%= render 'form', task: @task %>
+
+<%= link_to '戻る', tasks_path %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -2,4 +2,6 @@
 <p>title: <%= @task.title %></p>
 <p>description: <%= @task.description %></p>
 
+<%= link_to '編集する', edit_task_path(@task) %>
+<br>
 <%= link_to "戻る", tasks_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,7 @@ module App
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,213 @@
+---
+ja:
+  activerecord:
+    models:
+      task: 'タスク'
+    attributes:
+      task:
+        name: 'タスク名'
+        description: 'タスクの詳細'
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後


### PR DESCRIPTION
# ステップ9: アプリの日本語部分を共通化しよう
- Railsのi18nの仕組みを利用して、validation エラーメッセージを日本語で出力するようにしましょう

## 変更点
config/application.rbの変更
config/locales/ja.ymlの追加
エラーが日本語化しているかどうかの確認のための簡単なvalidatesの設定

## 動作画面
![スクリーンショット 2021-08-20 11 56 03](https://user-images.githubusercontent.com/67850944/130172896-4c966ef1-0c26-43d9-8a7c-704c2d38d34b.png)