### PR TITLE
ステップ10: Railsのタイムゾーンを設定しよう

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,7 @@ module App
     config.generators.system_tests = nil
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
# ステップ10: Railsのタイムゾーンを設定しよう
- Railsのタイムゾーンを日本（東京）に設定しましょう

## 変更点
application.rbにおいてtimezoneの変更

## 動作画面
![スクリーンショット 2021-08-20 12 17 09](https://user-images.githubusercontent.com/67850944/130173950-4713fc80-d284-407b-8bdb-32d5ae09ad40.png)

参考：https://qiita.com/aosho235/items/a31b895ce46ee5d3b444