### PR TITLE
ステップ21: 複数人で利用できるようにしよう（ユーザの導入）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ ruby '2.6.2'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
 # require:false > rubocopはターミナルでしか使わないためinstallする必要はない
-gem 'rails-i18n', '~> 5.1'
 gem 'kaminari'
+gem 'rails-i18n', '~> 5.1'
 gem 'rubocop', require: false
 gem 'rubocop-rails', require: false
 gem 'rubocop-rspec'

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
+  belongs_to :user
+
   validates :title, presence: true, length: { maximum: 30 }
   validates :description, length: { maximum: 600 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  has_many :tasks, dependent: :destroy
+end

--- a/db/migrate/20210910071401_create_users.rb
+++ b/db/migrate/20210910071401_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :password_digest
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210910071401_create_users.rb
+++ b/db/migrate/20210910071401_create_users.rb
@@ -3,7 +3,7 @@ class CreateUsers < ActiveRecord::Migration[5.2]
     create_table :users do |t|
       t.string :name, null: false
       t.string :email, null: false, unique: true
-      t.string :password_digest
+      t.string :password_digest, null: false
       t.timestamps
     end
   end

--- a/db/migrate/20210910071401_create_users.rb
+++ b/db/migrate/20210910071401_create_users.rb
@@ -2,7 +2,7 @@ class CreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
       t.string :name, null: false
-      t.string :email, null: false
+      t.string :email, null: false, unique: true
       t.string :password_digest
       t.timestamps
     end

--- a/db/migrate/20210910072307_add_user_id_to_tasks.rb
+++ b/db/migrate/20210910072307_add_user_id_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddUserIdToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tasks, :user, foreign_key: true, default: 1
+  end
+end

--- a/db/migrate/20210910072307_add_user_id_to_tasks.rb
+++ b/db/migrate/20210910072307_add_user_id_to_tasks.rb
@@ -1,5 +1,5 @@
 class AddUserIdToTasks < ActiveRecord::Migration[5.2]
   def change
-    add_reference :tasks, :user, foreign_key: true, default: 1
+    add_reference :tasks, :user, index: true, foreign_key: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_06_081856) do
+ActiveRecord::Schema.define(version: 2021_09_10_072307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,18 @@ ActiveRecord::Schema.define(version: 2021_09_06_081856) do
     t.date "deadline_on"
     t.string "status", default: "未着手", null: false
     t.integer "priority", default: 0, null: false
+    t.bigint "user_id", default: 1
     t.index ["title"], name: "index_tasks_on_title"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "tasks", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 2021_09_10_072307) do
     t.date "deadline_on"
     t.string "status", default: "未着手", null: false
     t.integer "priority", default: 0, null: false
-    t.bigint "user_id", default: 1
+    t.bigint "user_id"
     t.index ["title"], name: "index_tasks_on_title"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 2021_09_10_072307) do
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
-    t.string "password_digest"
+    t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_06_081856) do
+ActiveRecord::Schema.define(version: 2021_09_10_072307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,18 @@ ActiveRecord::Schema.define(version: 2021_09_06_081856) do
     t.date "deadline_on"
     t.integer "status", default: 0, null: false
     t.integer "priority", default: 0, null: false
+    t.bigint "user_id"
     t.index ["title"], name: "index_tasks_on_title"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "tasks", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,7 @@
-User.create(name: 'taro', email: 'taro@example.com')
+User.create!(name: 'taro', email: 'taro@example.com')
+3.times do |n|
+  Task.create!(
+    title: "test#{n}",
+    user_id: User.find_by(email: 'taro@example.com').id
+  )
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,1 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+User.create(name: 'taro', email: 'taro@example.com')

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,8 @@
+namespace :users do
+  desc 'user_id: nilの既存レコードにseedで作成したユーザーを関連づける'
+  task accociate_user_id: :environment do
+    tasks = Task.where(user_id: nil)
+    user = User.find_by(name: 'taro', email: 'taro@example.com')
+    tasks.update(user_id: user.id)
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :user do
-    
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe Task, type: :model do
     let(:finished_task) { FactoryBot.create(:task, title: 'ccc', status: '完了') }
     let(:high_priority_task) { FactoryBot.create(:task, priority: '高') }
     let(:low_priority_task) { FactoryBot.create(:task, priority: '低') }
-    let(:finished_and_high_priority_task) { FactoryBot.create(:task, status: '完了', priority: '高') }
 
     it('is valid search for a title term') { expect(described_class.search(title_term: 'aaa')).to include(todo_task).and exclude(working_task, finished_task) }
 
@@ -60,6 +59,9 @@ RSpec.describe Task, type: :model do
 
     it('return an empty collection') { expect(described_class.search(title_term: 'zzz')).to be_empty }
 
-    it('return a high priority and finished task') { expect(described_class.search(status_term: '完了', priority_term: '高')).to include(finished_and_high_priority_task).and exclude(finished_task, high_priority_task) }
+    it 'return a high priority and finished task' do
+      finished_and_high_priority_task = FactoryBot.create(:task, status: '完了', priority: '高')
+      expect(described_class.search(status_term: '完了', priority_term: '高')).to include(finished_and_high_priority_task).and exclude(finished_task, high_priority_task)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
### ステップ21: 複数人で利用できるようにしよう（ユーザの導入）

- ユーザモデルを作成してみましょう
- 最初のユーザをseedで作成してみましょう
- ユーザとタスクが紐づくようにしましょう
  - 関連に対してインデックスを貼りましょう
  - ※ Herokuにデプロイした際に、すでに登録されているタスクとユーザが紐づいているようにしてください（データメンテナンス）
 
## 変更点
Userモデルの作成
1:多のリレーションをUserとTaskに貼る
Rakeでuser_idカラムがないものに対して自動でリレーションを設定するtaskを作成
seedでuserを作成できるように設定